### PR TITLE
Added support for specifying a build version and a command line optio…

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -85,17 +85,22 @@ func fireUpPProf() bool {
 
 }
 
-func dumpVersionAndExit(args []string) (string, bool) {
-	if len(args) == 2 && args[1] == "-version" {
-		version := BuildVersion
-		if version == "" {
-			version = "<not specified>"
-		}
+const versionNotSpecified = `%s%s: no build version specified. A version can be set on the
+command line using the –X –ldflags option, for example
+go build -ldflags "-X github.com/xtracdev/xavi/runner.BuildVersion=20160129.1"`
 
-		return fmt.Sprintf("%s: build version %s", args[0], version), true
+func dumpVersionAndExit(args []string) (string, bool) {
+	var versionFormat string
+
+	switch BuildVersion {
+	case "":
+		versionFormat = versionNotSpecified
+	default:
+		versionFormat = "%s: build version %s"
 	}
 
-	return BuildVersion, false
+	output := fmt.Sprintf(versionFormat, args[0], BuildVersion)
+	return output, len(args) == 2 && args[1] == "-version"
 }
 
 //Run starts a process delegating to the shell.DoMain function

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -15,6 +15,10 @@ import (
 	"strings"
 )
 
+//Build version is set via the command line, e.g.
+//go build -ldflags "-X github.com/xtracdev/xavi/runner.BuildVersion=20160129.1"
+var BuildVersion string
+
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	setLoggingLevel()
@@ -81,8 +85,28 @@ func fireUpPProf() bool {
 
 }
 
+func dumpVersionAndExit(args []string) (string, bool) {
+	if len(args) == 2 && args[1] == "-version" {
+		version := BuildVersion
+		if version == "" {
+			version = "<not specified>"
+		}
+
+		return fmt.Sprintf("%s: build version %s", args[0], version), true
+	}
+
+	return BuildVersion, false
+}
+
 //Run starts a process delegating to the shell.DoMain function
 func Run(args []string, pluginRegistrationFn func()) {
+	version, exit := dumpVersionAndExit(os.Args)
+	if exit == true {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	log.Info(version)
 	fireUpPProf()
 	kvs := setupXAVIEnvironment(pluginRegistrationFn)
 	os.Exit(shell.DoMain(args, kvs, os.Stdout))

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"strings"
 )
 
 func registerLoggingPlugin() {
@@ -74,7 +75,8 @@ func TestFireUpPProf(t *testing.T) {
 func TestVersionDefault(t *testing.T) {
 	args := []string{"mystuff", "-version"}
 	version, exit := dumpVersionAndExit(args)
-	assert.Equal(t, "mystuff: build version <not specified>", version)
+	assert.True(t, strings.Contains(version, "mystuff: no build version specified"))
+	assert.True(t, strings.Contains(version, "–X –ldflags option"))
 	assert.True(t, exit)
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -70,3 +70,24 @@ func TestFireUpPProf(t *testing.T) {
 	fired = fireUpPProf()
 	assert.True(t, fired)
 }
+
+func TestVersionDefault(t *testing.T) {
+	args := []string{"mystuff", "-version"}
+	version, exit := dumpVersionAndExit(args)
+	assert.Equal(t, "mystuff: build version <not specified>", version)
+	assert.True(t, exit)
+}
+
+func TestVersionNonDefault(t *testing.T) {
+	BuildVersion = "666"
+	args := []string{"mycoolapi", "-version"}
+	version, exit := dumpVersionAndExit(args)
+	assert.Equal(t, "mycoolapi: build version 666", version)
+	assert.True(t, exit)
+}
+
+func TestVersionNoExit(t *testing.T) {
+	args := []string{"a", "b"}
+	_, exit := dumpVersionAndExit(args)
+	assert.False(t, exit)
+}


### PR DESCRIPTION
Updates to set a build version from the build command line, and to display in either via a -version command line (followed by a process exit) or in the logging output.

Signed-off-by: d-smith doug.smith@fmr.com
