### PR TITLE
Feature panic handler

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -2,14 +2,13 @@ package env
 
 //Environment variable names used to pick up configuration are defined here.
 const (
-	KVStoreURL     = "XAVI_KVSTORE_URL"
-	LoggingOpts    = "XAVI_LOGGING_OPTS"
-	StatsdEndpoint = "XAVI_STATSD_ADDRESS"
-	LoggingLevel   = "XAVI_LOGGING_LEVEL"
+	KVStoreURL       = "XAVI_KVSTORE_URL"
+	LoggingOpts      = "XAVI_LOGGING_OPTS"
+	StatsdEndpoint   = "XAVI_STATSD_ADDRESS"
+	LoggingLevel     = "XAVI_LOGGING_LEVEL"
 	UseDataDogStatsD = "XAVI_USE_DATADOG_STATSD"
-	StatsdNamespace = "XAVI_STATSD_NAMESPACE"
-	DatadogHost = "XAVI_DDHOST"
-
+	StatsdNamespace  = "XAVI_STATSD_NAMESPACE"
+	DatadogHost      = "XAVI_DDHOST"
 )
 
 //Valid LoggingOpts - note that all can be specified in the env var, comma

--- a/logging/logginghook.go
+++ b/logging/logginghook.go
@@ -1,6 +1,5 @@
 package logging
 
-
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"

--- a/plugin/recovery/recovery.go
+++ b/plugin/recovery/recovery.go
@@ -1,0 +1,59 @@
+package recovery
+
+import (
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	"github.com/xtracdev/xavi/plugin"
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+//RecoveryContext defines a structure to allow a logging function and error message formulation
+//function to be used when handling a panic produced when servicing an http route.
+type RecoveryContext struct {
+	logFn    func(interface{})
+	errMsgFn func(interface{}) string
+}
+
+
+//defaultGlobalRecoveryContext defines the default logging and error message when handling a panic
+//produced servicing an http route
+var defaultGlobalRecoveryContext = &RecoveryContext{
+	logFn: func(r interface{}) {
+		var err error
+		switch t := r.(type) {
+		case string:
+			err = errors.New(t)
+		case error:
+			err = t
+		default:
+			err = errors.New("Unknown error")
+		}
+		log.Warn("Handled panic: ", err.Error())
+	},
+	errMsgFn: func(r interface{}) string {
+		return ""
+	},
+}
+
+//GlobalPanicRecoveryMiddleware defines a middleware that xavi wraps the http call chain in, such that a
+//panic that occurs in the service handling gets logged and an error status is returned to the client.
+//If a recovery context is provided, the logging and error message used in the panic handling is derived
+//using the functions passed in the recovery context. Otherwise, the default logging and error message
+//is used.
+func GlobalPanicRecoveryMiddleware(rc *RecoveryContext, h plugin.ContextHandler) plugin.ContextHandler {
+	return plugin.ContextHandlerFunc(func(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
+		if rc == nil {
+			rc = defaultGlobalRecoveryContext
+		}
+
+		defer func() {
+			r := recover()
+			if r != nil {
+				rc.logFn(r)
+				http.Error(rw, rc.errMsgFn(r), http.StatusInternalServerError)
+			}
+		}()
+		h.ServeHTTPContext(ctx, rw, req)
+	})
+}

--- a/plugin/recovery/recovery.go
+++ b/plugin/recovery/recovery.go
@@ -11,15 +11,15 @@ import (
 //RecoveryContext defines a structure to allow a logging function and error message formulation
 //function to be used when handling a panic produced when servicing an http route.
 type RecoveryContext struct {
-	logFn    func(interface{})
-	errMsgFn func(interface{}) string
+	LogFn          func(interface{})
+	ErrorMessageFn func(interface{}) string
 }
 
 
 //defaultGlobalRecoveryContext defines the default logging and error message when handling a panic
 //produced servicing an http route
 var defaultGlobalRecoveryContext = &RecoveryContext{
-	logFn: func(r interface{}) {
+	LogFn: func(r interface{}) {
 		var err error
 		switch t := r.(type) {
 		case string:
@@ -31,7 +31,7 @@ var defaultGlobalRecoveryContext = &RecoveryContext{
 		}
 		log.Warn("Handled panic: ", err.Error())
 	},
-	errMsgFn: func(r interface{}) string {
+	ErrorMessageFn: func(r interface{}) string {
 		return ""
 	},
 }
@@ -50,8 +50,8 @@ func GlobalPanicRecoveryMiddleware(rc *RecoveryContext, h plugin.ContextHandler)
 		defer func() {
 			r := recover()
 			if r != nil {
-				rc.logFn(r)
-				http.Error(rw, rc.errMsgFn(r), http.StatusInternalServerError)
+				rc.LogFn(r)
+				http.Error(rw, rc.ErrorMessageFn(r), http.StatusInternalServerError)
 			}
 		}()
 		h.ServeHTTPContext(ctx, rw, req)

--- a/plugin/recovery/recovery_test.go
+++ b/plugin/recovery/recovery_test.go
@@ -19,8 +19,8 @@ func TestSuppliedContextHandler(t *testing.T) {
 	errorMsg := false
 
 	rc := &RecoveryContext{
-		logFn: func(r interface{}) { logged = true },
-		errMsgFn: func(r interface{}) string {
+		LogFn: func(r interface{}) { logged = true },
+		ErrorMessageFn: func(r interface{}) string {
 			errorMsg = true
 			return ""
 		},

--- a/plugin/recovery/recovery_test.go
+++ b/plugin/recovery/recovery_test.go
@@ -18,7 +18,7 @@ func TestSuppliedContextHandler(t *testing.T) {
 	logged := false
 	errorMsg := false
 
-	rc := &RecoveryContext{
+	rc := RecoveryContext{
 		LogFn: func(r interface{}) { logged = true },
 		ErrorMessageFn: func(r interface{}) string {
 			errorMsg = true
@@ -26,7 +26,9 @@ func TestSuppliedContextHandler(t *testing.T) {
 		},
 	}
 
-	handler := GlobalPanicRecoveryMiddleware(rc, plugin.ContextHandlerFunc(handleBar))
+	recoveryWrapper := RecoveryWrapper{RecoveryContext: rc}
+
+	handler := recoveryWrapper.Wrap(plugin.ContextHandlerFunc(handleBar))
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
@@ -45,7 +47,9 @@ func TestSuppliedContextHandler(t *testing.T) {
 }
 
 func TestDefaultContextHandler(t *testing.T) {
-	handler := GlobalPanicRecoveryMiddleware(nil, plugin.ContextHandlerFunc(handleBar))
+	recoveryWrapper := NewRecoveryWrapper()
+
+	handler := recoveryWrapper.Wrap(plugin.ContextHandlerFunc(handleBar))
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),

--- a/plugin/recovery/recovery_test.go
+++ b/plugin/recovery/recovery_test.go
@@ -1,0 +1,62 @@
+package recovery
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/xtracdev/xavi/plugin"
+	"golang.org/x/net/context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func handleBar(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
+	panic("Kaboom")
+}
+
+func TestSuppliedContextHandler(t *testing.T) {
+
+	logged := false
+	errorMsg := false
+
+	rc := &RecoveryContext{
+		logFn: func(r interface{}) { logged = true },
+		errMsgFn: func(r interface{}) string {
+			errorMsg = true
+			return ""
+		},
+	}
+
+	handler := GlobalPanicRecoveryMiddleware(rc, plugin.ContextHandlerFunc(handleBar))
+
+	adapter := &plugin.ContextAdapter{
+		Ctx:     context.Background(),
+		Handler: handler,
+	}
+
+	ts := httptest.NewServer(adapter)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	assert.True(t, logged)
+	assert.True(t, errorMsg)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestDefaultContextHandler(t *testing.T) {
+	handler := GlobalPanicRecoveryMiddleware(nil, plugin.ContextHandlerFunc(handleBar))
+
+	adapter := &plugin.ContextAdapter{
+		Ctx:     context.Background(),
+		Handler: handler,
+	}
+
+	ts := httptest.NewServer(adapter)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	assert.Nil(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/plugin/timing/timingplugin.go
+++ b/plugin/timing/timingplugin.go
@@ -62,15 +62,15 @@ func TimerFromContext(ctx context.Context) *timer.EndToEndTimer {
 	return newCtx
 }
 
-type TimerWrapper struct{}
+type TimingWrapper struct{}
 
-func NewTimerWrapper() TimerWrapper {
-	return TimerWrapper{}
+func NewTimingWrapper() TimingWrapper {
+	return TimingWrapper{}
 }
 
 //Wrap implements the plugin Wrapper interface, and is used
 //to wrap a handler to put a EndToEndTimer instance into the call context
-func (tw TimerWrapper) Wrap(h plugin.ContextHandler) plugin.ContextHandler {
+func (tw TimingWrapper) Wrap(h plugin.ContextHandler) plugin.ContextHandler {
 	return plugin.ContextHandlerFunc(func(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
 		ctx = NewContextWithTimer(ctx, req)
 		h.ServeHTTPContext(ctx, rw, req)

--- a/plugin/timing/timingplugin.go
+++ b/plugin/timing/timingplugin.go
@@ -64,7 +64,7 @@ func TimerFromContext(ctx context.Context) *timer.EndToEndTimer {
 
 type TimingWrapper struct{}
 
-func NewTimingWrapper() TimingWrapper {
+func NewTimingWrapper() plugin.Wrapper {
 	return TimingWrapper{}
 }
 

--- a/plugin/timing/timingplugin.go
+++ b/plugin/timing/timingplugin.go
@@ -62,9 +62,15 @@ func TimerFromContext(ctx context.Context) *timer.EndToEndTimer {
 	return newCtx
 }
 
-//RequestTimerMiddleware implements the plugin Wrapper interface, and is used
+type TimerWrapper struct{}
+
+func NewTimerWrapper() TimerWrapper {
+	return TimerWrapper{}
+}
+
+//Wrap implements the plugin Wrapper interface, and is used
 //to wrap a handler to put a EndToEndTimer instance into the call context
-func RequestTimerMiddleware(h plugin.ContextHandler) plugin.ContextHandler {
+func (tw TimerWrapper) Wrap(h plugin.ContextHandler) plugin.ContextHandler {
 	return plugin.ContextHandlerFunc(func(ctx context.Context, rw http.ResponseWriter, req *http.Request) {
 		ctx = NewContextWithTimer(ctx, req)
 		h.ServeHTTPContext(ctx, rw, req)

--- a/plugin/timing/timingplugin_test.go
+++ b/plugin/timing/timingplugin_test.go
@@ -41,7 +41,7 @@ func TestContextPresent(t *testing.T) {
 	assert.NotNil(t, wrapperFactory)
 	handler := wrapperFactory.Wrap(plugin.ContextHandlerFunc(handleBar))
 
-	timerWrapper := NewTimerWrapper()
+	timerWrapper := NewTimingWrapper()
 
 	handler = timerWrapper.Wrap(handler)
 

--- a/plugin/timing/timingplugin_test.go
+++ b/plugin/timing/timingplugin_test.go
@@ -41,7 +41,9 @@ func TestContextPresent(t *testing.T) {
 	assert.NotNil(t, wrapperFactory)
 	handler := wrapperFactory.Wrap(plugin.ContextHandlerFunc(handleBar))
 
-	handler = RequestTimerMiddleware(handler)
+	timerWrapper := NewTimerWrapper()
+
+	handler = timerWrapper.Wrap(handler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/xtracdev/xavi/plugin/logging"
 	"io/ioutil"
 	"os"
-	"testing"
 	"strings"
+	"testing"
 )
 
 func registerLoggingPlugin() {

--- a/service/managed_service.go
+++ b/service/managed_service.go
@@ -6,19 +6,11 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/xtracdev/xavi/plugin"
-	"github.com/xtracdev/xavi/plugin/recovery"
 	"github.com/xtracdev/xavi/plugin/timing"
 	"golang.org/x/net/context"
 	"net/http"
 	"strings"
 )
-
-var httpRecoveryContext *recovery.RecoveryContext = nil
-
-//SetGlobalHttpRecoveryContext is used to set a non-default RecoveryContext for HTTP call handling
-func SetGlobalHttpRecoveryContext(rc *recovery.RecoveryContext) {
-	httpRecoveryContext = rc
-}
 
 //Managed service contains the configuration we boot a listener from.
 type managedService struct {
@@ -246,7 +238,6 @@ func (ms *managedService) Run() {
 	uriHandlerMap := ms.mapUrisToRoutes()
 	for uri, handler := range uriHandlerMap {
 		handler = timing.RequestTimerMiddleware(handler)
-		handler = recovery.GlobalPanicRecoveryMiddleware(httpRecoveryContext, handler)
 		adapter := &plugin.ContextAdapter{
 			Ctx:     context.Background(),
 			Handler: handler,

--- a/service/managed_service.go
+++ b/service/managed_service.go
@@ -6,11 +6,19 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/xtracdev/xavi/plugin"
+	"github.com/xtracdev/xavi/plugin/recovery"
 	"github.com/xtracdev/xavi/plugin/timing"
 	"golang.org/x/net/context"
 	"net/http"
 	"strings"
 )
+
+var httpRecoveryContext *recovery.RecoveryContext = nil
+
+//SetGlobalHttpRecoveryContext is used to set a non-default RecoveryContext for HTTP call handling
+func SetGlobalHttpRecoveryContext(rc *recovery.RecoveryContext) {
+	httpRecoveryContext = rc
+}
 
 //Managed service contains the configuration we boot a listener from.
 type managedService struct {
@@ -238,6 +246,7 @@ func (ms *managedService) Run() {
 	uriHandlerMap := ms.mapUrisToRoutes()
 	for uri, handler := range uriHandlerMap {
 		handler = timing.RequestTimerMiddleware(handler)
+		handler = recovery.GlobalPanicRecoveryMiddleware(httpRecoveryContext, handler)
 		adapter := &plugin.ContextAdapter{
 			Ctx:     context.Background(),
 			Handler: handler,

--- a/service/managed_service.go
+++ b/service/managed_service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/xtracdev/xavi/plugin"
-	"github.com/xtracdev/xavi/plugin/timing"
 	"golang.org/x/net/context"
 	"net/http"
 	"strings"
@@ -237,7 +236,6 @@ func (ms *managedService) Run() {
 
 	uriHandlerMap := ms.mapUrisToRoutes()
 	for uri, handler := range uriHandlerMap {
-		handler = timing.RequestTimerMiddleware(handler)
 		adapter := &plugin.ContextAdapter{
 			Ctx:     context.Background(),
 			Handler: handler,

--- a/service/multiroute_server_test.go
+++ b/service/multiroute_server_test.go
@@ -77,7 +77,7 @@ func TestMRConfigListener(t *testing.T) {
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
-		Handler: timing.NewTimerWrapper().Wrap(uriHandlerMap[fooURI]),
+		Handler: timing.NewTimingWrapper().Wrap(uriHandlerMap[fooURI]),
 	}
 	ls := httptest.NewServer(adapter)
 	defer ls.Close()

--- a/service/multiroute_server_test.go
+++ b/service/multiroute_server_test.go
@@ -77,7 +77,7 @@ func TestMRConfigListener(t *testing.T) {
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
-		Handler: timing.RequestTimerMiddleware(uriHandlerMap[fooURI]),
+		Handler: timing.NewTimerWrapper().Wrap(uriHandlerMap[fooURI]),
 	}
 	ls := httptest.NewServer(adapter)
 	defer ls.Close()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -90,7 +90,7 @@ func TestPostRequest(t *testing.T) {
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
-		Handler: timing.NewTimerWrapper().Wrap(plugin.ContextHandlerFunc(handlerFn)),
+		Handler: timing.NewTimingWrapper().Wrap(plugin.ContextHandlerFunc(handlerFn)),
 	}
 
 	ts2 := httptest.NewServer(adapter)
@@ -134,7 +134,7 @@ func TestPostRequestWithPlugin(t *testing.T) {
 
 	wrapper := makeTestWrapper()
 	wrappedHandler := (wrapper.Wrap(plugin.ContextHandlerFunc(handlerFn)))
-	wrappedHandler = timing.NewTimerWrapper().Wrap(wrappedHandler)
+	wrappedHandler = timing.NewTimingWrapper().Wrap(wrappedHandler)
 
 	t.Log("When the echo server is proxied with a wrapped handler")
 
@@ -381,7 +381,7 @@ func validateURIHandlerMap(handlers map[string]plugin.ContextHandler, t *testing
 	assert.Nil(t, handlers["no way, Jose"])
 
 	handler := handlers["/foo"]
-	handler = timing.NewTimerWrapper().Wrap(handler)
+	handler = timing.NewTimingWrapper().Wrap(handler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
@@ -443,7 +443,7 @@ func TestGuardFnGenWithBrokerHeaderProp(t *testing.T) {
 	uriHandlerMap := makeURIHandlerMap(uriToGuardAndHandlerMap)
 
 	handler := uriHandlerMap["/foo"]
-	handler = timing.NewTimerWrapper().Wrap(handler)
+	handler = timing.NewTimingWrapper().Wrap(handler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -487,6 +487,8 @@ func TestPanickyPostRequestWithPlugin(t *testing.T) {
 	logged := false
 	errorMsg := false
 
+	//Create the recovery context, and set the test recovery context indirectly via
+	//SetGlobalHttpRecoveryContext and package variable httpRecoveryContext
 	rc := &recovery.RecoveryContext{
 		LogFn: func(r interface{}) { logged = true },
 		ErrorMessageFn: func(r interface{}) string {
@@ -494,6 +496,8 @@ func TestPanickyPostRequestWithPlugin(t *testing.T) {
 			return ""
 		},
 	}
+
+	SetGlobalHttpRecoveryContext(rc)
 
 	ts := httptest.NewServer(http.HandlerFunc(postHandler))
 	defer ts.Close()
@@ -510,7 +514,7 @@ func TestPanickyPostRequestWithPlugin(t *testing.T) {
 	wrapper := makeTestPanicWrapper()
 	wrappedHandler := (wrapper.Wrap(plugin.ContextHandlerFunc(handlerFn)))
 	wrappedHandler = timing.RequestTimerMiddleware(wrappedHandler)
-	wrappedHandler = recovery.GlobalPanicRecoveryMiddleware(rc, wrappedHandler)
+	wrappedHandler = recovery.GlobalPanicRecoveryMiddleware(httpRecoveryContext, wrappedHandler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -90,7 +90,7 @@ func TestPostRequest(t *testing.T) {
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
-		Handler: timing.RequestTimerMiddleware(plugin.ContextHandlerFunc(handlerFn)),
+		Handler: timing.NewTimerWrapper().Wrap(plugin.ContextHandlerFunc(handlerFn)),
 	}
 
 	ts2 := httptest.NewServer(adapter)
@@ -134,7 +134,7 @@ func TestPostRequestWithPlugin(t *testing.T) {
 
 	wrapper := makeTestWrapper()
 	wrappedHandler := (wrapper.Wrap(plugin.ContextHandlerFunc(handlerFn)))
-	wrappedHandler = timing.RequestTimerMiddleware(wrappedHandler)
+	wrappedHandler = timing.NewTimerWrapper().Wrap(wrappedHandler)
 
 	t.Log("When the echo server is proxied with a wrapped handler")
 
@@ -381,7 +381,7 @@ func validateURIHandlerMap(handlers map[string]plugin.ContextHandler, t *testing
 	assert.Nil(t, handlers["no way, Jose"])
 
 	handler := handlers["/foo"]
-	handler = timing.RequestTimerMiddleware(handler)
+	handler = timing.NewTimerWrapper().Wrap(handler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),
@@ -443,7 +443,7 @@ func TestGuardFnGenWithBrokerHeaderProp(t *testing.T) {
 	uriHandlerMap := makeURIHandlerMap(uriToGuardAndHandlerMap)
 
 	handler := uriHandlerMap["/foo"]
-	handler = timing.RequestTimerMiddleware(handler)
+	handler = timing.NewTimerWrapper().Wrap(handler)
 
 	adapter := &plugin.ContextAdapter{
 		Ctx:     context.Background(),

--- a/statsd/statsd_support.go
+++ b/statsd/statsd_support.go
@@ -4,18 +4,16 @@ import (
 	"bytes"
 	log "github.com/Sirupsen/logrus"
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/datadog"
 	"github.com/xtracdev/xavi/env"
 	"os"
 	"strings"
 	"time"
-	"github.com/armon/go-metrics/datadog"
 )
-
 
 func init() {
 	initializeFromEnvironmentSettings()
 }
-
 
 func configureStatsD(endpoint string) {
 	namespace := os.Getenv(env.StatsdNamespace)
@@ -50,7 +48,7 @@ func configureDatadogStatsd(endpoint string, namespace string) {
 func configureVanillaStatsD(envEndpoint string, namespace string) {
 	log.Info("Using vanilla statsd client to send telemetry to ", envEndpoint)
 	sink, err := metrics.NewStatsdSink(envEndpoint)
-	if err != nil{
+	if err != nil {
 		log.Warn("Unable to configure statds sink", err.Error())
 		return
 	}
@@ -65,7 +63,7 @@ func initializeFromEnvironmentSettings() {
 		configureStatsD(envSettings)
 	} else {
 		log.Info("Using in memory metrics accumulator - dump via USR1 signal")
-		inm := metrics.NewInmemSink(10*time.Second, 5 * time.Minute)
+		inm := metrics.NewInmemSink(10*time.Second, 5*time.Minute)
 		metrics.DefaultInmemSignal(inm)
 		metrics.NewGlobal(metrics.DefaultConfig("xavi"), inm)
 	}


### PR DESCRIPTION
This pull request implements a panic recovery plugin, and a way to set a global recovery structure that xavi will use in the call chain. See plugin/recovery/recovery.go for details on the RecoveryContext structure, and service/managed_service for the function SetGlobalHttpRecoveryContext, which is used to set the RecoveryContext that http routes are wrapped in.
