### PR TITLE
Feature timer tags

### DIFF
--- a/timer/timer.go
+++ b/timer/timer.go
@@ -40,6 +40,7 @@ type Contributor struct {
 type EndToEndTimer struct {
 	sync.RWMutex
 	Name             string
+	Tags             map[string]string
 	Duration         time.Duration
 	LoggingTimestamp time.Time `json:"time"`
 	TxnId            string
@@ -57,6 +58,7 @@ func NewEndToEndTimer(name string) *EndToEndTimer {
 		TxnId: makeTxnId(),
 		Name:  name,
 		start: time.Now(),
+		Tags:  make(map[string]string),
 	}
 }
 

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -3,6 +3,7 @@ package timer
 import (
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -14,6 +15,17 @@ func TestPostitiveDuration(t *testing.T) {
 	assert.False(t, at.errorReported)
 	assert.True(t, at.ErrorFree)
 	assert.Equal(t, "", at.Error)
+}
+
+func TestTagsGetSerialized(t *testing.T) {
+	at := NewEndToEndTimer("foo")
+	at.Tags["foo"] = "1"
+	at.Tags["bar"] = "2"
+	at.Stop(nil)
+
+	s := at.ToJSONString()
+	assert.True(t, strings.Contains(s, `"bar":"2"`), "unexpected bar tag")
+	assert.True(t, strings.Contains(s, `"foo":"1"`), "unexpected foo tag")
 }
 
 func TestContributors(t *testing.T) {


### PR DESCRIPTION
Added the ability to add additional context to timers that appears in the serialized timer string. Useful for downstream analytics.
