### PR TITLE
Health check fix

### DIFF
--- a/loadbalancer/prefer-local.go
+++ b/loadbalancer/prefer-local.go
@@ -208,6 +208,8 @@ func (pl *PreferLocalLoadBalancer) GetEndpoints() ([]string, []string) {
 
 	if pl.LocalServers != nil {
 		lh, luh := pl.LocalServers.GetEndpoints()
+		fmt.Printf("%v\n", lh)
+		fmt.Printf("%v\n", luh)
 		healthy = append(healthy, lh...)
 		unhealthy = append(unhealthy, luh...)
 	}

--- a/loadbalancer/prefer-local.go
+++ b/loadbalancer/prefer-local.go
@@ -204,8 +204,19 @@ func (pl *PreferLocalLoadBalancer) MarkEndpointUp(endpoint string) error {
 //GetEndpoints returns the endpoints associated with the load balancer, partitioning
 //the set of endpoints into healthy and unhealthy endpoints
 func (pl *PreferLocalLoadBalancer) GetEndpoints() ([]string, []string) {
-	lh, luh := pl.LocalServers.GetEndpoints()
-	rh, ruh := pl.RemoteServers.GetEndpoints()
+	var healthy, unhealthy []string
 
-	return append(lh, rh...), append(luh, ruh...)
+	if pl.LocalServers != nil {
+		lh, luh := pl.LocalServers.GetEndpoints()
+		healthy = append(healthy, lh...)
+		unhealthy = append(unhealthy, luh...)
+	}
+
+	if pl.RemoteServers != nil {
+		rh, ruh := pl.RemoteServers.GetEndpoints()
+		healthy = append(healthy, rh...)
+		unhealthy = append(unhealthy, ruh...)
+	}
+
+	return healthy, unhealthy
 }

--- a/loadbalancer/prefer-local.go
+++ b/loadbalancer/prefer-local.go
@@ -208,8 +208,6 @@ func (pl *PreferLocalLoadBalancer) GetEndpoints() ([]string, []string) {
 
 	if pl.LocalServers != nil {
 		lh, luh := pl.LocalServers.GetEndpoints()
-		fmt.Printf("%v\n", lh)
-		fmt.Printf("%v\n", luh)
 		healthy = append(healthy, lh...)
 		unhealthy = append(unhealthy, luh...)
 	}

--- a/loadbalancer/prefer_local_test.go
+++ b/loadbalancer/prefer_local_test.go
@@ -289,3 +289,23 @@ func TestPrefLocalWithLocalhost(t *testing.T) {
 	}
 
 }
+
+func TestGetEndpointsNoRemoteServers(t *testing.T) {
+	var preferLocalFactory LoadBalancerFactory = new(PreferLocalLoadBalancerFactory)
+	pllb, err := preferLocalFactory.NewLoadBalancer("foo", "", makeTestLocalServer())
+	assert.Nil(t, err)
+	assert.NotNil(t, pllb)
+	h, uh := pllb.GetEndpoints()
+	assert.Equal(t, len(h), 1)
+	assert.Equal(t, len(uh), 0)
+}
+
+func TestGetEndpointsNoLocalServers(t *testing.T) {
+	var preferLocalFactory LoadBalancerFactory = new(PreferLocalLoadBalancerFactory)
+	pllb, err := preferLocalFactory.NewLoadBalancer("foo", "", makeTestRemoteServer())
+	assert.Nil(t, err)
+	assert.NotNil(t, pllb)
+	h, uh := pllb.GetEndpoints()
+	assert.Equal(t, len(h), 1)
+	assert.Equal(t, len(uh), 0)
+}

--- a/loadbalancer/roundrobin.go
+++ b/loadbalancer/roundrobin.go
@@ -153,8 +153,10 @@ func (rr *RoundRobinLoadBalancer) GetEndpoints() ([]string, []string) {
 			if loadBalancingEndpoint.Up {
 				healthy = append(healthy, loadBalancingEndpoint.Address)
 			} else {
-				unhealthy = append(healthy, loadBalancingEndpoint.Address)
+				unhealthy = append(unhealthy, loadBalancingEndpoint.Address)
 			}
+		} else {
+			log.Error("Something unexpected found in endpoint map")
 		}
 	})
 


### PR DESCRIPTION
Health check fix that checks local and remote load balancers for nil before grabbing endpoints, and a fix to the GetEndpoints method on the round robin load balancer that fix miswrite of unhealthy endpoints.
