### PR TITLE
Short circuited custom health check registration when not listening

### DIFF
--- a/commands/listen.go
+++ b/commands/listen.go
@@ -36,6 +36,8 @@ func (l *Listen) Help() string {
 
 //Run executes the Listen command with the supplied arguments
 func (l *Listen) Run(args []string) int {
+	config.ListenContext = true
+
 	var listener, address, cpuprofile string
 	cmdFlags := flag.NewFlagSet("listen", flag.ContinueOnError)
 	cmdFlags.Usage = func() { l.UI.Error(l.Help()) }

--- a/config/config.go
+++ b/config/config.go
@@ -14,3 +14,6 @@ func readKey(key string, kvs kvstore.KVStore) ([]byte, error) {
 	log.Info("Read key " + key)
 	return kvs.Get(key)
 }
+
+//ListenContext is set to true if the listen command is being executed
+var ListenContext bool

--- a/config/customhc.go
+++ b/config/customhc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/xtracdev/xavi/kvstore"
 	"net/http"
+	log "github.com/Sirupsen/logrus"
 )
 
 //HealthCheckFn defines the signature of custom health checks
@@ -24,9 +25,16 @@ func HealthCheckForServer(server string) HealthCheckFn {
 }
 
 //RegisterHealthCheckForServer registers a custom health check function for a given server. The
-//configuration store is check for the existance of the specified server definition prior to
+//configuration store is check for the existence of the specified server definition prior to
 //storing the health check function.
 func RegisterHealthCheckForServer(kvs kvstore.KVStore, server string, hcfn HealthCheckFn) error {
+	//Health check registration is done when starting a listener, and relies on several
+	//configuration definitions having been defined earlier. For the case where the framework
+	//is not being used to run a listener, we do not attempt to register the health check.
+	if ListenContext == false {
+		return nil
+	}
+
 	//Must register something if this is called.
 	if hcfn == nil {
 		return ErrNoHealthCheckFn
@@ -49,6 +57,18 @@ func RegisterHealthCheckForServer(kvs kvstore.KVStore, server string, hcfn Healt
 //RegisterHealthCheckForBackend registers the given health check for every server associated with the
 //given backend
 func RegisterHealthCheckForBackend(kvs kvstore.KVStore, backend string, hcfn HealthCheckFn) error {
+	log.Infof("Registering custom health check function for %s", backend)
+
+	//Health check registration is done when starting a listener, and relies on several
+	//configuration definitions having been defined earlier. For the case where the framework
+	//is not being used to run a listener, we do not attempt to register the health check.
+	if ListenContext == false {
+		log.Info("Context indicates not listening - ignoring registration of custom health check")
+		return nil
+	}
+
+
+
 	//Must register something if this is called.
 	if hcfn == nil {
 		return ErrNoHealthCheckFn

--- a/config/customhc_test.go
+++ b/config/customhc_test.go
@@ -18,7 +18,9 @@ func simpleHC(endpoint string, transport *http.Transport) <-chan bool {
 
 func TestCustomHCNoFunction(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
+	ListenContext = true
 	err := RegisterHealthCheckForServer(kvs, "not a server name", nil)
+	ListenContext = false
 	if assert.NotNil(t, err) {
 		assert.Equal(t, err, ErrNoHealthCheckFn)
 	}
@@ -26,7 +28,9 @@ func TestCustomHCNoFunction(t *testing.T) {
 
 func TestCustomHCNoSuchServer(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
+	ListenContext = true
 	err := RegisterHealthCheckForServer(kvs, "not a server name", simpleHC)
+	ListenContext = false
 	if assert.NotNil(t, err) {
 		assert.Equal(t, err, ErrNoSuchServer)
 	}
@@ -35,7 +39,9 @@ func TestCustomHCNoSuchServer(t *testing.T) {
 func TestCustomHCLookup(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
 	var hc1 HealthCheckFn = simpleHC
+	ListenContext = true
 	err := RegisterHealthCheckForServer(kvs, "server1", hc1)
+	ListenContext = false
 
 	if assert.Nil(t, err) {
 		hcfn := HealthCheckForServer("server1")
@@ -45,7 +51,9 @@ func TestCustomHCLookup(t *testing.T) {
 
 func TestCustomHCNoSuchBackend(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
+	ListenContext = true
 	err := RegisterHealthCheckForBackend(kvs, "Not a backend", simpleHC)
+	ListenContext = false
 	if assert.NotNil(t, err) {
 		assert.Equal(t, err, ErrNoSuchBackend)
 	}
@@ -53,7 +61,9 @@ func TestCustomHCNoSuchBackend(t *testing.T) {
 
 func TestCustomHCNoFnForBackend(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
+	ListenContext = true
 	err := RegisterHealthCheckForBackend(kvs, "Not a backend", nil)
+	ListenContext = false
 	if assert.NotNil(t, err) {
 		assert.Equal(t, err, ErrNoHealthCheckFn)
 	}
@@ -62,7 +72,9 @@ func TestCustomHCNoFnForBackend(t *testing.T) {
 func TestCustomHCBackendConfig(t *testing.T) {
 	kvs := BuildKVStoreTestConfig(t)
 	var hc1 HealthCheckFn = simpleHC
+	ListenContext = true
 	err := RegisterHealthCheckForBackend(kvs, "hello-backend", hc1)
+	ListenContext = false
 	if assert.Nil(t, err) {
 		hcfn := HealthCheckForServer("server1")
 		assert.NotNil(t, hcfn)

--- a/loadbalancer/healthcheck_test.go
+++ b/loadbalancer/healthcheck_test.go
@@ -138,7 +138,9 @@ func TestHCCustomHealthy(t *testing.T) {
 		return statusChannel
 	}
 
+	config.ListenContext = true
 	config.RegisterHealthCheckForServer(kvs, "server1", hcfn)
+	config.ListenContext = false
 
 	//Create the healthcheck function and invoke it
 	healthcheckFn := MakeHealthCheck(lbEndpoint, serverConfig, false)

--- a/loadbalancer/lbutils.go
+++ b/loadbalancer/lbutils.go
@@ -13,10 +13,10 @@ import (
 )
 
 type BackendLoadBalancer struct {
-	LoadBalancer  LoadBalancer
-	BackendConfig *config.BackendConfig
-	CertPool      *x509.CertPool
-	httpTransport *http.Transport
+	LoadBalancer   LoadBalancer
+	BackendConfig  *config.BackendConfig
+	CertPool       *x509.CertPool
+	httpTransport  *http.Transport
 	httpsTransport *http.Transport
 }
 
@@ -103,16 +103,16 @@ func NewBackendLoadBalancer(backendName string) (*BackendLoadBalancer, error) {
 	httpsTransport := &http.Transport{DisableKeepAlives: false, DisableCompression: false, TLSClientConfig: tlsConfig}
 
 	//Create non-TLS transport
-	httpTransport :=  &http.Transport{DisableKeepAlives: false, DisableCompression: false}
+	httpTransport := &http.Transport{DisableKeepAlives: false, DisableCompression: false}
 
 	lb, err := factory.NewLoadBalancer(backendConfig.Name, backendConfig.CACertPath, servers)
 
 	return &BackendLoadBalancer{
-		LoadBalancer: lb,
-		BackendConfig: backendConfig,
-		CertPool: certPool,
-		httpsTransport:httpsTransport,
-		httpTransport:httpTransport,
+		LoadBalancer:   lb,
+		BackendConfig:  backendConfig,
+		CertPool:       certPool,
+		httpsTransport: httpsTransport,
+		httpTransport:  httpTransport,
 	}, err
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"github.com/xtracdev/xavi/config"
 )
 
 //Build version is set via the command line, e.g.
 //go build -ldflags "-X github.com/xtracdev/xavi/runner.BuildVersion=20160129.1"
 var BuildVersion string
-
 
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
@@ -131,6 +131,10 @@ func Run(args []string, pluginRegistrationFn func()) {
 	log.Info(version)
 	fireUpPProf()
 	kvs := setupXAVIEnvironment(pluginRegistrationFn)
+
+	if len(os.Args) > 1 && os.Args[1] == "listen" {
+		config.ListenContext = true
+	}
 
 	for _, f := range initKVSFuncs {
 		err := f(kvs)


### PR DESCRIPTION
This pull request fixes issue #32 by ensuring the registration of custom health checks is only done when booting a listener.
