### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/loadbalancer/lbutils.go
+++ b/loadbalancer/lbutils.go
@@ -75,7 +75,7 @@ func createCertPool(backendConfig *config.BackendConfig) (*x509.CertPool, error)
 	return pool, nil
 }
 
-// NewLoadBalancer instantiates a load balancer based on the named backend configuration. Backend
+// NewBackendLoadBalancer instantiates a load balancer based on the named backend configuration. Backend
 // names are scoped to routes, thus the route is given to ensure the correct backend is returned
 // if multiple backend definitions with the same name are given.
 func NewBackendLoadBalancer(backendName string) (*BackendLoadBalancer, error) {

--- a/service/health.go
+++ b/service/health.go
@@ -68,7 +68,7 @@ func (hcc *HealthCheckContext) HealthHandler() http.HandlerFunc {
 	}
 }
 
-//Return current health status
+//GetHealthStatus returns current health status
 func (hcc *HealthCheckContext) GetHealthStatus() *HealthResponse {
 
 	hr := &HealthResponse{


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?